### PR TITLE
Add support for prefect HPC task runner using dask-jobqueue

### DIFF
--- a/global_scripts/dataset.py
+++ b/global_scripts/dataset.py
@@ -292,11 +292,15 @@ class Dataset(ABC):
 
             if task_runner == "sequential":
                 tr = SequentialTaskRunner
+            elif task_runner == "concurrent" or task_runner is None:
+                tr = ConcurrentTaskRunner
             elif task_runner == "dask":
                 from prefect_dask import DaskTaskRunner
                 tr = DaskTaskRunner(**kwargs)
-            elif task_runner == "concurrent" or task_runner is None:
-                tr = ConcurrentTaskRunner
+            elif task_runner == "hpc":
+                from hpc import HPCDaskTaskRunner
+                job_name = "".join(self.name.split())
+                tr = HPCDaskTaskRunner(num_procs=max_workers, job_name=job_name, **kwargs)
             else:
                 raise ValueError("Prefect task runner not recognized")
 

--- a/global_scripts/hpc.py
+++ b/global_scripts/hpc.py
@@ -1,0 +1,64 @@
+import math
+from typing import Optional
+from dask_jobqueue import PBSCluster
+from prefect_dask.task_runners import DaskTaskRunner
+
+vortex_cluster_kwargs = {
+    "shebang": "#!/bin/tcsh",
+    "resource_spec": "nodes=1:c18a:ppn=12",
+    "cores": 12,
+    "processes": 12,
+    "memory": "30GB",
+    "interface": "ib0",
+}
+
+# these have not yet been tuned
+hima_cluster_kwargs = {
+    "shebang": "#!/bin/tcsh",
+    "resource_spec": "nodes=1:c18a:ppn=12",
+    "cores": 12,
+    "processes": 12,
+    "memory": "30GB",
+    "interface": "ib0",
+}
+
+
+def get_cluster_kwargs(
+    job_name: str,
+    cluster: str="vortex",
+    cores_per_process: Optional[int] = None,
+    walltime: str = "01:00:00",
+    **kwargs
+) -> dict:
+    if cluster == "vortex":
+        cluster_kwargs = vortex_cluster_kwargs
+    elif cluster == "hima":
+        cluster_kwargs = hima_cluster_kwargs
+        raise NotImplementedError("Hima cluster not yet supported")
+    else:
+        raise ValueError("Cluster name not recognized")
+    cluster_kwargs["name"] = job_name
+    cluster_kwargs["walltime"] = walltime
+    cluster_kwargs.update(kwargs)
+    if cores_per_process:
+        cluster_kwargs["processes"] = math.floor(
+            cluster_kwargs["cores"] / cores_per_process
+        )
+    return cluster_kwargs
+
+
+def hpc_dask_cluster(num_procs: int, **kwargs) -> PBSCluster:
+    cluster_kwargs = get_cluster_kwargs(**kwargs)
+    cluster = PBSCluster(**cluster_kwargs)
+    cluster.scale(num_procs)
+    return cluster
+
+
+class HPCDaskTaskRunner(DaskTaskRunner):
+    def __init__(self, num_procs: int, **kwargs):
+        dask_task_runner_kwargs = {
+            "cluster_class": PBSCluster,
+            "cluster_kwargs": get_cluster_kwargs(**kwargs),
+            "adapt_kwargs": {"minimum": num_procs, "maximum": num_procs},
+        }
+        super().__init__(**dask_task_runner_kwargs)


### PR DESCRIPTION
`global_scripts/hpc.py` provides `HPCDaskTaskRunner()`, which is imported into `global_scripts/dataset.py` when a dataset is run with the following parameters:
- `backend="prefect"`
- `task_runner="hpc"`

The `hpc.py` module offers a richer API for customizing which cluster to use, how many cores to assign to each process, etc. For now I haven't integrated many of these options into `dataset.py`.

The code in `global_scripts/hpc.py` is originally from a side project of mine that was licensed under GPLv3. As the copyright holder, by submitting this pull request I am releasing it under the MIT license.

Closes #109