### PR TITLE
Log result stats of each task run

### DIFF
--- a/global_scripts/dataset.py
+++ b/global_scripts/dataset.py
@@ -185,6 +185,13 @@ class Dataset(ABC):
         if len(results) == 0:
             raise ValueError(f"Task run {name} yielded no results. Did it receive any inputs?")
 
+        success_count = sum(1 for r in results if r.status_code == 0)
+        error_count = len(results) - success_count
+        if error_count == 0:
+            logger.info(f"Task run {name} completed with {success_count} successes and no errors")
+        else:
+            logger.warning(f"Task run {name} completed with {error_count} errors and {success_count} successes")
+
         return ResultTuple(results, name, timestamp)
 
 


### PR DESCRIPTION
Logs a warning if there were any errors, info otherwise

Note that if we ever allow task runs to return futures, we may need to rethink how we log results. For now though, this provides useful feedback that helps test task runs without having to manually inspect logs every time.

Closes #110