### PR TITLE
Add task retry options to Dataset class

### DIFF
--- a/global_scripts/dataset.py
+++ b/global_scripts/dataset.py
@@ -136,12 +136,10 @@ class Dataset(ABC):
         results = []
         for f in futures:
             state = f[1].wait()
-            print(state.name)
-            if state.name == "Completed":
-                status_code = 0
+            if state.is_completed():
+                results.append(TaskResult(0, "Success", f[0], state.result()))
             else:
-                status_code = 1
-            results.append(TaskResult(status_code, state.name, f[0], state.result()))
+                results.append(TaskResult(1, repr(state.result(raise_on_failure=False)), f[0], None))
 
         return results
 
@@ -327,7 +325,7 @@ class Dataset(ABC):
         log_dir: str="logs",
         logger_level=logging.INFO,
         retries: int=3,
-        retry_delay: int=30,
+        retry_delay: int=5,
         **kwargs):
         """
         Run a dataset

--- a/global_scripts/dataset.py
+++ b/global_scripts/dataset.py
@@ -127,11 +127,9 @@ class Dataset(ABC):
 
         from prefect import task
 
-        @task(name=name, retries=self.retries, retry_delay_seconds=self.retry_delay)
-        def task_wrapper(self, func, args):
-            return func(*args)
+        task_wrapper = task(func, name=name, retries=self.retries, retry_delay_seconds=self.retry_delay)
 
-        futures =  [(i, task_wrapper.submit(self, func, i)) for i in input_list]
+        futures =  [(i, task_wrapper.submit(*i)) for i in input_list]
 
         results = []
         for f in futures:


### PR DESCRIPTION
- both run() and run_tasks() take two new parameters, `retry` and `retry_delay`. the former sets the number of times a task will re-run if it fails, and the latter the number of seconds to wait between retries
- run_tasks() overrides run() parameters for that specific run
- works with Prefect as well as other backends

I tested this fairly well with the Prefect, local, and MPI backends. There are a few scenarios I haven't tested this code with though, so we may need to adjust as we go.

Closes #111, closes #112