### PR TITLE
Have deployments use a global scratch directory

### DIFF
--- a/global_scripts/deploy_jobscript
+++ b/global_scripts/deploy_jobscript
@@ -7,6 +7,6 @@
 module load anaconda3/2021.05
 conda activate geodata38
 
-setenv TMPDIR /sciclone/scr20
+setenv TMPDIR /sciclone/scr20/sgoodman
 
 prefect agent start -q geodata

--- a/global_scripts/deploy_jobscript
+++ b/global_scripts/deploy_jobscript
@@ -1,0 +1,12 @@
+#!/bin/tcsh
+#PBS -N asg:gq_deploy
+#PBS -l nodes=1:c18a:ppn=1
+#PBS -l walltime=12:00:00
+#PBS -j oe
+
+module load anaconda3/2021.05
+conda activate geodata38
+
+setenv TMPDIR /sciclone/scr20
+
+prefect agent start -q geodata

--- a/global_scripts/deploy_jobscript
+++ b/global_scripts/deploy_jobscript
@@ -7,6 +7,6 @@
 module load anaconda3/2021.05
 conda activate geodata38
 
-setenv TMPDIR /sciclone/scr20/sgoodman
+setenv TMPDIR /sciclone/scr20/$USER
 
 prefect agent start -q geodata

--- a/global_scripts/hpc.py
+++ b/global_scripts/hpc.py
@@ -10,17 +10,6 @@ vortex_cluster_kwargs = {
     "processes": 12,
     "memory": "30GB",
     "interface": "ib0",
-    # "job_script_prologue": [
-    #     "source /usr/local/anaconda3-2021.05/etc/profile.d/conda.csh",
-    #     "module load gcc/9.3.0 openmpi/3.1.4/gcc-9.3.0 anaconda3/2021.05",
-    #     "conda activate geodata38",
-    #     "set tmpdir=`mktemp -d`",
-    #     "cd $tmpdir",
-    #     "git clone -b develop https://github.com/aiddata/geo-datasets.git",
-    #     "cd geo-datasets/malaria_atlas_project",
-    #     "cp ../global_scripts/* ."
-    # ],
-    # "log_directory": "/sciclone/home20/smgoodman"
 }
 
 # these have not yet been tuned
@@ -56,6 +45,7 @@ def get_cluster_kwargs(
         del kwargs['cluster_kwargs']
         
     cluster_kwargs.update(kwargs)
+
     if cores_per_process:
         cluster_kwargs["processes"] = math.floor(
             cluster_kwargs["cores"] / cores_per_process

--- a/malaria_atlas_project/config.ini
+++ b/malaria_atlas_project/config.ini
@@ -33,7 +33,7 @@ directory = malaria_atlas_project
 [deploy]
 
 deployment_name = malaria_atlas_project_pf_prevalence_rate
-version = 202
+version = 1
 flow_file_name = flow
 flow_name = malaria_atlas_project
 storage_block = geo-datasets-github

--- a/malaria_atlas_project/flow.py
+++ b/malaria_atlas_project/flow.py
@@ -1,60 +1,32 @@
-import sys
 import os
+import sys
 from pathlib import Path
-from configparser import ConfigParser
 from datetime import datetime
+from configparser import ConfigParser
 
 from prefect import flow
 from prefect.filesystems import GitHub
+
+from main import MalariaAtlasProject
 
 
 config_file = "malaria_atlas_project/config.ini"
 config = ConfigParser()
 config.read(config_file)
 
-
 block_name = config["deploy"]["storage_block"]
 GitHub.load(block_name).get_directory('global_scripts')
 
-sys.path.insert(1, os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), config["github"]["directory"]))
-
-from main import MalariaAtlasProject
-
+tmp_dir = Path(os.getcwd()) / config["github"]["directory"]
 
 @flow
 def malaria_atlas_project(raw_dir, output_dir, years, dataset, overwrite_download, overwrite_processing, backend, task_runner, run_parallel, max_workers, cores_per_process, log_dir):
- 
+
     timestamp = datetime.today()
-    time_format_str: str="%Y_%m_%d_%H_%M"
-    time_str = timestamp.strftime(time_format_str)
+    time_str = timestamp.strftime("%Y_%m_%d_%H_%M")
     timestamp_log_dir = Path(log_dir) / time_str
     timestamp_log_dir.mkdir(parents=True, exist_ok=True)
 
-    cluster_kwargs = {
-        "shebang": "#!/bin/tcsh",
-        "resource_spec": "nodes=1:c18a:ppn=12",
-        "cores": 12,
-        "processes": 12,
-        "memory": "30GB",
-        "interface": "ib0",
-        "job_extra_directives": [
-            "#PBS -j oe",
-            # "#PBS -o ",
-            # "#PBS -e ",
-        ],
-        "job_script_prologue": [
-            "source /usr/local/anaconda3-2021.05/etc/profile.d/conda.csh",
-            "module load gcc/9.3.0 openmpi/3.1.4/gcc-9.3.0 anaconda3/2021.05",
-            "conda activate geodata38",
-            "set tmpdir=`mktemp -d`",
-            "cd $tmpdir",
-            "git clone -b develop https://github.com/aiddata/geo-datasets.git",
-            "cd geo-datasets/malaria_atlas_project",
-            "cp ../global_scripts/* ."
-        ],
-        "log_directory": str(timestamp_log_dir)
-    }
-
     class_instance = MalariaAtlasProject(raw_dir, output_dir, years, dataset, overwrite_download, overwrite_processing)
 
-    class_instance.run(backend=backend, task_runner=task_runner, run_parallel=run_parallel, max_workers=max_workers, cores_per_process=cores_per_process, log_dir=timestamp_log_dir, cluster_kwargs=cluster_kwargs)
+    class_instance.run(backend=backend, task_runner=task_runner, run_parallel=run_parallel, max_workers=max_workers, cores_per_process=cores_per_process, log_dir=timestamp_log_dir, job_script_prologue=[f"cd {tmp_dir}"])

--- a/malaria_atlas_project/flow.py
+++ b/malaria_atlas_project/flow.py
@@ -27,6 +27,25 @@ def malaria_atlas_project(raw_dir, output_dir, years, dataset, overwrite_downloa
     timestamp_log_dir = Path(log_dir) / time_str
     timestamp_log_dir.mkdir(parents=True, exist_ok=True)
 
+
+    cluster_kwargs = {
+        "shebang": "#!/bin/tcsh",
+        "resource_spec": "nodes=1:c18a:ppn=12",
+        "cores": 12,
+        "processes": 12,
+        "memory": "30GB",
+        "interface": "ib0",
+        "job_extra_directives": [
+            "#PBS -j oe",
+            # "#PBS -o ",
+            # "#PBS -e ",
+        ],
+        "job_script_prologue": [
+            f"cd {tmp_dir}",
+        ],
+        "log_directory": str(timestamp_log_dir)
+    }
+
     class_instance = MalariaAtlasProject(raw_dir, output_dir, years, dataset, overwrite_download, overwrite_processing)
 
-    class_instance.run(backend=backend, task_runner=task_runner, run_parallel=run_parallel, max_workers=max_workers, cores_per_process=cores_per_process, log_dir=timestamp_log_dir, job_script_prologue=[f"cd {tmp_dir}"])
+    class_instance.run(backend=backend, task_runner=task_runner, run_parallel=run_parallel, max_workers=max_workers, cores_per_process=cores_per_process, log_dir=timestamp_log_dir, cluster_kwargs=cluster_kwargs)


### PR DESCRIPTION
When a Prefect agent downloads a deployment from a GitHub storage block, it [places it into a temporary directory](https://github.com/PrefectHQ/prefect/blob/5fb17cec3c716d4603ee91c87862a1db6842b794/src/prefect/filesystems.py#L907-L908) created using Python's built-in library [tempfile](https://docs.python.org/3/library/tempfile.html). The issue we've been dealing with is that when using DaskTaskRunner with dask-jobqueue on the HPC to run Prefect tasks on PBS jobs, compute nodes have failed to run tasks because they could not access the local temporary directory that Prefect put the scripts into.

Previous to this PR, we've been using an approach which involves having each compute node [clone the git repository itself](https://github.com/aiddata/geo-datasets/blob/develop/malaria_atlas_project/flow.py#L45-L54), and then use that code as a basis for its task run. I think that it will be easier in the long-run to let Prefect deployments manage our code to as great extent as possible. I'm concerned that while cloning the repository again in job_script_prologue works most of the time, pulling from GitHub from each compute node introduces more room for error, e.g. different commits getting served to different nodes.

tempfile [prefers `$TMPDIR`](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir) when creating temporary directories. I suggest that we set `$TMPDIR` to a global scratch directory, so that Prefect agent puts the code into a place where all compute nodes can see it. This can be done using `setenv`:
```sh
setenv TMPDIR /sciclone/scr20/jwhall
```
I've also added `deploy_jobscript` to the `global_scripts` directory, that automatically sets `$TMPDIR` and starts a Prefect agent. This will standardize how we run Prefect agent, and allow us to adjust its behavior in the future. This jobscript could be submitted regularly so that there is always an agent ready to run any deployments.

I've tested this new system and it works great! *knocks on wood*