### PR TITLE
Log HPC job script to log_dir

### DIFF
--- a/global_scripts/dataset.py
+++ b/global_scripts/dataset.py
@@ -398,7 +398,7 @@ class Dataset(ABC):
             elif task_runner == "hpc":
                 from hpc import HPCDaskTaskRunner
                 job_name = "".join(self.name.split())
-                tr = HPCDaskTaskRunner(num_procs=max_workers, job_name=job_name, **kwargs)
+                tr = HPCDaskTaskRunner(num_procs=max_workers, job_name=job_name, log_dir=self.log_dir, **kwargs)
             else:
                 raise ValueError("Prefect task runner not recognized")
 


### PR DESCRIPTION
When running a dataset using the Dataset class using "hpc" mode, it is rather difficult to access the underlying PBSCluster within the HPCDaskTaskRunner.  When debugging I often just want to see what job script was sent out to compute nodes. This PR logs that job scrip to the log_dir.